### PR TITLE
[mppa256] -fdata-sections CFLAG Freezes Execution

### DIFF
--- a/mppa256/make/makefile.cflags
+++ b/mppa256/make/makefile.cflags
@@ -143,7 +143,7 @@ ifeq ($(RELEASE), true)
 	export CFLAGS += -fconserve-stack
 	export CFLAGS += -fcx-fortran-rules
 	export CFLAGS += -fcx-limited-range
-	export CFLAGS += -fdata-sections
+	# export CFLAGS += -fdata-sections                               # === FREEZE EXECUTION       ===
 	export CFLAGS += -fearly-inlining
 	# export CFLAGS += -fexceptions                                  # Not Supported in MPPA-256
 	export CFLAGS += -ffinite-math-only


### PR DESCRIPTION
In this PR, I comment -fdata-sections CFLAG because it freezes signal benchmark execution.

## Recreating the problem

Running the [nanvix/benchmarks:1b54a7b](https://github.com/nanvix/benchmarks/tree/1b54a7bb0b1f1240d2a6c277f035ef31176da4ba) in `ONLY_MAILBOX` mode will freeze CC master in signal function in the signal-barrier benchmark.
The problem can appear in broadcast and gather benchmarks too.