### PR TITLE
[build] LibMPI Build Files

### DIFF
--- a/makefile.libmpi
+++ b/makefile.libmpi
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Builds contrib.
+contrib: contrib-multikernel
+
+# Builds contrib headers.
+contrib-headers: contrib-headers-multikernel
+
+# Cleans contrib.
+contrib-uninstall: contrib-uninstall-multikernel
+
+# Cleans contrib headers.
+contrib-uninstall-headers: contrib-uninstall-headers-multikernel
+
+#===============================================================================
+# Microkernel
+#===============================================================================
+
+# Builds Microkernel.
+contrib-multikernel: make-dirs
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+
+# Builds Microkernel headers.
+contrib-headers-multikernel: make-dirs
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-headers RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+
+# Cleans Microkernel.
+contrib-uninstall-multikernel:
+	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall RELEASE=$(RELEASE)
+
+# Cleans Microkernel headers.
+contrib-uninstall-headers-multikernel:
+	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall-headers RELEASE=$(RELEASE)

--- a/mppa256/make/makefile.libmpi
+++ b/mppa256/make/makefile.libmpi
@@ -1,0 +1,100 @@
+#
+# MIT License
+#
+# Copyright(c) 2011-2020 The Maintainers of Nanvix
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+include $(MAKEDIR)/makefile
+
+#===============================================================================
+
+# Builds everything.
+all-target: all-k1bio all-k1bdp
+
+# Builds everything for node cluster variant.
+all-k1bdp:
+	@$(MAKE) -C $(SRCDIR) all                          \
+		CFLAGS="$(CFLAGS) -D __k1bdp__ -mcluster=node" \
+		LDFLAGS="$(LDFLAGS) -mcluster=node"            \
+		LINKERDIR=$(BUILDDIR)/mppa256/linker/k1bdp     \
+		LIBMPI=libmpi-k1bdp.a                          \
+		LIBRUNTIME=libruntime-k1bdp.a                  \
+		LIBC=libc-k1bdp.a                              \
+		LIBNAVNIX=libnanvix-k1bdp.a                    \
+		LIBKERNEL=libkernel-k1bdp.a                    \
+		LIBHAL=libhal-k1bdp.a                          \
+		BARELIB=barelib-k1bdp.a                        \
+		OBJ_SUFFIX=k1bdp
+
+# Builds everything for ioddr node variant.
+all-k1bio:
+	@$(MAKE) -C $(SRCDIR) all                           \
+		CFLAGS="$(CFLAGS) -D __k1bio__ -mcluster=ioddr" \
+		LDFLAGS="$(LDFLAGS) -mcluster=ioddr"            \
+		LINKERDIR=$(BUILDDIR)/mppa256/linker/k1bio      \
+		LIBMPI=libmpi-k1bio.a                           \
+		LIBRUNTIME=libruntime-k1bio.a                   \
+		LIBC=libc-k1bio.a                               \
+		LIBNANVIX=libnanvix-k1bio.a                     \
+		LIBKERNEL=libkernel-k1bio.a                     \
+		LIBHAL=libhal-k1bio.a                           \
+		BARELIB=barelib-k1bio.a                         \
+		OBJ_SUFFIX=k1bio
+
+# Cleans object files.
+clean-target: clean-k1bdp clean-k1bio
+
+# Cleans object files for node cluster variant.
+clean-k1bdp:
+	@$(MAKE) -C $(SRCDIR) clean \
+		OBJ_SUFFIX=k1bdp
+
+# Cleans object files for ioddr node variant.
+clean-k1bio:
+	@$(MAKE) -C $(SRCDIR) clean \
+		OBJ_SUFFIX=k1bio
+
+# Cleans everything.
+distclean-target: distclean-k1bdp distclean-k1bio
+
+# Cleans everything for node cluster variant.
+distclean-k1bdp: clean-k1bdp
+	@$(MAKE) -C $(SRCDIR) distclean   \
+		LIBRUNTIME=libruntime-k1bdp.a \
+		LIBMPI=libmpi-k1bdp.a         \
+		LIBC=libc-k1bdp.a             \
+		LIBNANVIX=libnanvix-k1bdp.a   \
+		LIBKERNEL=libkernel-k1bdp.a   \
+		LIBHAL=libhal-k1bdp.a         \
+		BARELIB=barelib-k1bdp.a       \
+		OBJ_SUFFIX=k1bdp
+
+# Cleans everything for ioddr variant.
+distclean-k1bio: clean-k1bio
+	@$(MAKE) -C $(SRCDIR) distclean   \
+		LIBMPI=libmpi-k1bio.a         \
+		LIBRUNTIME=libruntime-k1bio.a \
+		LIBC=libc-k1bio.a             \
+		LIBNANVIX=libnanvix-k1bio.a   \
+		LIBKERNEL=libkernel-k1bio.a   \
+		LIBHAL=libhal-k1bio.a         \
+		BARELIB=barelib-k1bio.a       \
+		OBJ_SUFFIX=k1bio

--- a/unix64/make/makefile.libmpi
+++ b/unix64/make/makefile.libmpi
@@ -22,29 +22,18 @@
 # SOFTWARE.
 #
 
-# Compiler Options
-ifneq ($(LIBLWIP),)
-CFLAGS += -I $(INCDIR)/posix
-endif
+include $(MAKEDIR)/makefile
 
-# Libraries
-LIBS := -Wl,--whole-archive
-LIBS += $(LIBDIR)/$(LIBHAL)
-LIBS += $(LIBDIR)/$(LIBKERNEL)
-LIBS += $(LIBDIR)/$(LIBRUNTIME)
-LIBS += -Wl,--no-whole-archive
-LIBS += $(LIBDIR)/$(LIBC)
-LIBS += $(LIBDIR)/$(LIBMPI)
-LIBS += $(LIBDIR)/$(LIBNANVIX)
-ifneq ($(LIBLWIP),)
-LIBS += $(LIBDIR)/$(LIBLWIP)
-endif
-LIBS += $(LIBDIR)/$(BARELIB) $(THEIR_LIBS)
+#===============================================================================
 
-# Linker Options
-ifeq ($(TARGET),unix64)
-LINKER_SCRIPT=
-else
-LINKER_SCRIPT = -L $(LINKERDIR)/ -T link.ld
-endif
+# Builds everything.
+all-target: make-dirs
+	@$(MAKE) -C $(SRCDIR) all
 
+# Cleans object files.
+clean-target:
+	@$(MAKE) -C $(SRCDIR) clean
+
+# Cleans everything.
+distclean-target:
+	@$(MAKE) -C $(SRCDIR) distclean


### PR DESCRIPTION
# Description #
In this PR we added the LibMPI Build Files for Unix64 and MPPA-256.

# Related Issues #
- Closes #12 - [LIBMPI Build Files](https://github.com/nanvix/build/issues/12)