### PR TITLE
[mppa256] Fix microkernel-benchmarks Makefile

### DIFF
--- a/mppa256/make/makefile.microkernel-benchmarks
+++ b/mppa256/make/makefile.microkernel-benchmarks
@@ -35,9 +35,8 @@ all-k1bdp:
 		CFLAGS="$(CFLAGS) -D __k1bdp__ -mcluster=node" \
 		LDFLAGS="$(LDFLAGS) -mcluster=node"            \
 		LINKERDIR=$(BUILDDIR)/mppa256/linker/k1bdp     \
-		LIBRUNTIME=libruntime-k1bdp.a                  \
 		LIBC=libc-k1bdp.a                              \
-		LIBNAVNIX=libnanvix-k1bdp.a                    \
+		LIBNANVIX=libnanvix-k1bdp.a                    \
 		LIBKERNEL=libkernel-k1bdp.a                    \
 		LIBHAL=libhal-k1bdp.a                          \
 		BARELIB=barelib-k1bdp.a                        \
@@ -49,7 +48,6 @@ all-k1bio:
 		CFLAGS="$(CFLAGS) -D __k1bio__ -mcluster=ioddr" \
 		LDFLAGS="$(LDFLAGS) -mcluster=ioddr"            \
 		LINKERDIR=$(BUILDDIR)/mppa256/linker/k1bio      \
-		LIBRUNTIME=libruntime-k1bio.a                   \
 		LIBC=libc-k1bio.a                               \
 		LIBNANVIX=libnanvix-k1bio.a                     \
 		LIBKERNEL=libkernel-k1bio.a                     \
@@ -76,7 +74,6 @@ distclean-target: distclean-k1bdp distclean-k1bio
 # Cleans everything for node cluster variant.
 distclean-k1bdp: clean-k1bdp
 	@$(MAKE) -C $(SRCDIR) distclean   \
-		LIBRUNTIME=libruntime-k1bdp.a \
 		LIBC=libc-k1bdp.a             \
 		LIBNANVIX=libnanvix-k1bdp.a   \
 		LIBKERNEL=libkernel-k1bdp.a   \
@@ -87,7 +84,6 @@ distclean-k1bdp: clean-k1bdp
 # Cleans everything for ioddr variant.
 distclean-k1bio: clean-k1bio
 	@$(MAKE) -C $(SRCDIR) distclean   \
-		LIBRUNTIME=libruntime-k1bio.a \
 		LIBC=libc-k1bio.a             \
 		LIBNANVIX=libnanvix-k1bio.a   \
 		LIBKERNEL=libkernel-k1bio.a   \


### PR DESCRIPTION
In this PR, I fix the name of `LIBNANVIX` flag and remove `RUNTIME` flag in microkernel-benchmarks makefile.