### PR TITLE
[bugfix] LibMPI Compilation

### DIFF
--- a/makefile.libmpi
+++ b/makefile.libmpi
@@ -40,20 +40,20 @@ contrib-uninstall-headers: contrib-uninstall-headers-multikernel
 
 # Builds Microkernel.
 contrib-multikernel: make-dirs
-	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib RELEASE=$(RELEASE)
-	$(MAKE) -C $(CONTRIBDIR)/multikernel install PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib LIBMPI="" RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
 
 # Builds Microkernel headers.
 contrib-headers-multikernel: make-dirs
-	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-headers RELEASE=$(RELEASE)
-	$(MAKE) -C $(CONTRIBDIR)/multikernel install-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-headers LIBMPI="" RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install-headers LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
 
 # Cleans Microkernel.
 contrib-uninstall-multikernel:
-	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
-	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall LIBMPI="" RELEASE=$(RELEASE)
 
 # Cleans Microkernel headers.
 contrib-uninstall-headers-multikernel:
-	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
-	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall-headers RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall-headers LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall-headers LIBMPI="" RELEASE=$(RELEASE)

--- a/mppa256/make/makefile.libmpi
+++ b/mppa256/make/makefile.libmpi
@@ -38,7 +38,7 @@ all-k1bdp:
 		LIBMPI=libmpi-k1bdp.a                          \
 		LIBRUNTIME=libruntime-k1bdp.a                  \
 		LIBC=libc-k1bdp.a                              \
-		LIBNAVNIX=libnanvix-k1bdp.a                    \
+		LIBNANVIX=libnanvix-k1bdp.a                    \
 		LIBKERNEL=libkernel-k1bdp.a                    \
 		LIBHAL=libhal-k1bdp.a                          \
 		BARELIB=barelib-k1bdp.a                        \


### PR DESCRIPTION
# Description #
In this PR some small corrections were made to the `makefile.libmpi` files. Namely, they were adjusted to get inline with the new abstract hierarchy and a small correction were made related to the compilation in MPPA-256 where the name of one of the libraries was wrong.