### PR TITLE
[linker] Move LibMPI to --no-whole-archive

### DIFF
--- a/makefile.config
+++ b/makefile.config
@@ -39,12 +39,12 @@ endif
 # Dependent No Whole Libraries
 LIBS += -Wl,--no-whole-archive
 LIBS += $(MODULES)
-
-# Interdependent No Whole Libraries
-LIBS += -Wl,--start-group
 ifneq ($(LIBMPI),)
 LIBS += $(LIBDIR)/$(LIBMPI)
 endif
+
+# Interdependent No Whole Libraries
+LIBS += -Wl,--start-group
 ifneq ($(LIBRUNTIME),)
 LIBS += $(LIBDIR)/$(LIBRUNTIME)
 endif


### PR DESCRIPTION
In this PR, I move the LibMPI to `--no-whole-archive` linker position because the LibMPI execution broke with it within the linking group.