### PR TITLE
[build][lwmpi] Added NANVIX_LWMPI Flag

### DIFF
--- a/makefile.benchmarks
+++ b/makefile.benchmarks
@@ -35,25 +35,25 @@ contrib-uninstall: contrib-uninstall-libmpi
 contrib-uninstall-headers: contrib-uninstall-headers-libmpi
 
 #===============================================================================
-# Microkernel
+# LWMPI
 #===============================================================================
 
-# Builds Microkernel.
+# Builds LWMPI.
 contrib-libmpi: make-dirs
 	$(MAKE) -C $(CONTRIBDIR)/libmpi contrib RELEASE=$(RELEASE) SUPPRESS_TESTS=true
-	$(MAKE) -C $(CONTRIBDIR)/libmpi install PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
+	$(MAKE) -C $(CONTRIBDIR)/libmpi install PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true NANVIX_LWMPI=$(NANVIX_LWMPI)
 
-# Builds Microkernel headers.
+# Builds LWMPI headers.
 contrib-headers-libmpi: make-dirs
 	$(MAKE) -C $(CONTRIBDIR)/libmpi contrib-headers RELEASE=$(RELEASE) SUPPRESS_TESTS=true
-	$(MAKE) -C $(CONTRIBDIR)/libmpi install-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
+	$(MAKE) -C $(CONTRIBDIR)/libmpi install-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true NANVIX_LWMPI=$(NANVIX_LWMPI)
 
-# Cleans Microkernel.
+# Cleans LWMPI.
 contrib-uninstall-libmpi:
 	$(MAKE) -C $(CONTRIBDIR)/libmpi uninstall PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 	$(MAKE) -C $(CONTRIBDIR)/libmpi contrib-uninstall RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 
-# Cleans Microkernel headers.
+# Cleans LWMPI headers.
 contrib-uninstall-headers-libmpi:
 	$(MAKE) -C $(CONTRIBDIR)/libmpi uninstall-headers PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 	$(MAKE) -C $(CONTRIBDIR)/libmpi contrib-uninstall-headers RELEASE=$(RELEASE) SUPPRESS_TESTS=true

--- a/makefile.libmpi
+++ b/makefile.libmpi
@@ -35,25 +35,25 @@ contrib-uninstall: contrib-uninstall-multikernel
 contrib-uninstall-headers: contrib-uninstall-headers-multikernel
 
 #===============================================================================
-# Microkernel
+# Multikernel
 #===============================================================================
 
-# Builds Microkernel.
+# Builds Multikernel.
 contrib-multikernel: make-dirs
 	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib LIBMPI="" RELEASE=$(RELEASE) SUPPRESS_TESTS=true
-	$(MAKE) -C $(CONTRIBDIR)/multikernel install LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true NANVIX_LWMPI=$(NANVIX_LWMPI)
 
-# Builds Microkernel headers.
+# Builds Multikernel headers.
 contrib-headers-multikernel: make-dirs
 	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-headers LIBMPI="" RELEASE=$(RELEASE) SUPPRESS_TESTS=true
-	$(MAKE) -C $(CONTRIBDIR)/multikernel install-headers LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
+	$(MAKE) -C $(CONTRIBDIR)/multikernel install-headers LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true NANVIX_LWMPI=$(NANVIX_LWMPI)
 
-# Cleans Microkernel.
+# Cleans Multikernel.
 contrib-uninstall-multikernel:
 	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall LIBMPI="" RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 
-# Cleans Microkernel headers.
+# Cleans Multikernel headers.
 contrib-uninstall-headers-multikernel:
 	$(MAKE) -C $(CONTRIBDIR)/multikernel uninstall-headers LIBMPI="" PREFIX=$(ROOTDIR) RELEASE=$(RELEASE) SUPPRESS_TESTS=true
 	$(MAKE) -C $(CONTRIBDIR)/multikernel contrib-uninstall-headers LIBMPI="" RELEASE=$(RELEASE) SUPPRESS_TESTS=true


### PR DESCRIPTION
# Description #
In this PR, we added the ```NANVIX_LWMPI``` flag to the build system, in order to signalize to the runtime when an application uses LWMPI. We included this flag both in ```Benchmarks``` and ```Libmpi``` repositories, which cascades to the Multikernel to evaluate if the runtime should initialize MPI Processes or not.